### PR TITLE
Taks#4  changes for caching and proxy server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 *.launch
 .settings/
 *.sublime-workspace
+/coverage
 
 # IDE - VSCode

--- a/README.md
+++ b/README.md
@@ -92,3 +92,11 @@ same data. If a query is not in cache we should call-through to the API.
 _**Implement the solution and make a PR from the branch `feat_proxy_server` to `master`**_
 
 > It is important to get the implementation working before trying to organize and clean it up.
+
+The solution has been implemented in the pull request
+=> from stocks ui shell the API call will be happening to the default host
+=> the proxy config will capture any ajax call and proxy to api server
+=> In api server used library @hapi/wreck to make the http call to third party
+=> Used another library @hapi/catbox-memory for in m emory aching
+=> based on the input parameters key for caching will be created symbol:period
+=> if cache has data API call will be avoided. If not API call will happen and populate the cache

--- a/apps/stocks-api/src/environments/environment.ts
+++ b/apps/stocks-api/src/environments/environment.ts
@@ -1,7 +1,10 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
-
-export const environment = {
-  production: false
+import { StocksAppConfig } from '@coding-challenge/stocks/data-access-app-config';
+export const environment: StocksAppConfig = {
+  production: false,
+  apiKey: 'Tpk_9f91dd3b21c94daf8ea8d9dd53240251',
+   apiURL: 'https://sandbox.iexapis.com'
+  //apiURL: 'https://cloud.iexapis.com'
 };

--- a/apps/stocks-api/src/main.ts
+++ b/apps/stocks-api/src/main.ts
@@ -3,21 +3,72 @@
  * This is only a minimal backend to get started.
  **/
 import { Server } from 'hapi';
-
+import  * as Wreck from '@hapi/wreck';
+import { environment }  from './environments/environment';
+import * as Catboxmemory from '@hapi/catbox-memory';
+import { from } from 'rxjs';
+//@Inject(StocksAppConfigToken) private env: StocksAppConfig,
 const init = async () => {
   const server = new Server({
     port: 3333,
-    host: 'localhost'
+    host: 'localhost',
+    cache: [{
+        name: 'stock-cache',
+        provider: {
+          constructor: Catboxmemory
+        }
+    }]
+  });
+
+  // server.route({
+  //   method: 'GET',
+  //   path: '/',
+  //   handler: (request, h) => {
+  //     console.log('base');
+  //     return {
+  //       hello: 'world'
+  //     };
+  //   }
+  // });
+
+  const getStock = async(symbol,period) => {
+    const { res, payload } =await Wreck.get(`${environment.apiURL}/beta/stock/${symbol}/chart/${period}?token=${environment.apiKey}`);
+
+          return payload;
+  }
+
+  const stockCache = server.cache({
+    cache: 'stock-cache',
+    expiresIn: 60*1000,
+    segment: 'customSegment',
+    // generateFunc: async(id) => {
+    //   return await getStock(id['a'],id['b']);
+    // },
+    //generateTimeout: 2000
   });
 
   server.route({
     method: 'GET',
-    path: '/',
-    handler: (request, h) => {
-      return {
-        hello: 'world'
-      };
-    }
+    path: '/api/{symbol}/{period}',
+    handler: async (request, h) => {
+          const { symbol, period} = request.params;
+          
+          const id = `${symbol}:${period}`;
+          const fromCache = await stockCache.get(id);
+          if (fromCache) {
+            console.log('item found'); 
+            return fromCache;
+          }
+          console.log('item not found'); 
+          const fromAPi = await getStock(symbol,period);
+          await stockCache.set(id, fromAPi, 500000);
+          return fromAPi;
+          //await Wreck.get(`${environment.apiURL}/beta/stock/${request.params.symbol}/chart/${request.params.period}?token=${environment.apiKey}`);
+
+          //return payload;
+        }
+      
+    
   });
 
   await server.start();

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,5 +1,5 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="chartData"
   [title]="chart.title"
   [type]="chart.type"
   [data]="chartData"

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -24,9 +24,7 @@ export class PriceQueryEffects {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
         return this.httpClient
           .get(
-            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
-              action.period
-            }?token=${this.env.apiKey}`
+            `/api/${action.symbol}/${action.period}`
           )
           .pipe(
             map(resp => new PriceQueryFetched(resp as PriceQueryResponse[]))

--- a/package-lock.json
+++ b/package-lock.json
@@ -933,6 +933,43 @@
         }
       }
     },
+    "@hapi/boom": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.0.0.tgz",
+      "integrity": "sha512-D+Or4yahLq3L7D1Jf0fR1+Lgr+HPK1lej8tc6hS/fBLmK66XdpvTyKv8YUR5ls1GeQy+KGtbpKAs+ZxyzNtUyA==",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+    },
+    "@hapi/catbox-memory": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.3.tgz",
+      "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
+    },
+    "@hapi/wreck": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
     "lodash": "^4.17.11",
     "lodash-es": "^4.17.11",
     "rxjs": "6.3.3",
-    "zone.js": "^0.8.26"
+    "zone.js": "^0.8.26",
+    "@hapi/catbox-memory": "^5.0.0",
+    "@hapi/wreck": "^17.0.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.13.0",


### PR DESCRIPTION
The solution has been implemented in the pull request
=> from stocks ui shell the API call will be happening to the default host
=> the proxy config will capture any ajax call and proxy to api server
=> In api server used library @hapi/wreck to make the http call to third party
=> Used another library @hapi/catbox-memory for in m emory aching
=> based on the input parameters key for caching will be created symbol:period
=> if cache has data API call will be avoided. If not API call will happen and populate the cache